### PR TITLE
Fixed the example which was "The capital of India is #{capitals[India]}"...

### DIFF
--- a/refresher.md
+++ b/refresher.md
@@ -117,7 +117,7 @@ previously established rule.
       :email, "al@wormhole.com"
     }
 
-    puts "The capital of India is #{capitals[India]}"
+    puts "The capital of India is #{capitals['India']}"
     puts "Contact me at #{person[:email]}"
 
     capitals.each do |k, v|


### PR DESCRIPTION
... – my assumption is that this early on, we shouldn't get a constant error :)
